### PR TITLE
Remove reference to Icons from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,12 +24,6 @@
     }
   ],
   
-  "icons": {
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  },
-  
   "browser_specific_settings": {
     "gecko": {
       "id": "blueprint-playground@example.com"


### PR DESCRIPTION
Ran into error: "Could not load icon ‘icons/icon16.png’ specified in ‘icons’. Could not load manifest,"